### PR TITLE
test.sh updates

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,62 @@
 #!/bin/bash
 
-bundle exec rspec || STATUS=$?
-yarn test || STATUS=$?
-PLTCOLLECTS=":$(pwd)/lib" raco test spec/ || STATUS=$?
-while read line; do
-  ./spec/support/test-c.sh "$line" || STATUS=$?
-done < <(find spec -name '*_spec.c')
-./spec/support/haskell.rb || STATUS=$?
+case "$1" in
+  ruby)
+    shift
+    bundle exec rspec "$@" || STATUS=$?
+    ;;
+  javascript)
+    shift
+    yarn test "$@" || STATUS=$?
+    ;;
+  c)
+    shift
 
-echo $STATUS
+    if [ $# -eq 0 ]; then
+      while read line; do
+        ./spec/support/test-c.sh "$line" || STATUS=$?
+      done < <(find spec -name '*_spec.c')
+    else
+      for line in "$@"; do
+        ./spec/support/test-c.sh "$line" || STATUS=$?
+      done
+    fi
+    ;;
+  racket|scheme)
+    shift
+    if [ $# -eq 0 ]; then
+      PLTCOLLECTS=":$(pwd)/lib" raco test spec/ || STATUS=$?
+    else
+      PLTCOLLECTS=":$(pwd)/lib" raco test "$@" || STATUS=$?
+    fi
+    ;;
+  haskell)
+    shift
+    ./spec/support/haskell.rb "$@" || STATUS=$?
+    ;;
+  '')
+    bundle exec rspec || STATUS=$?
+
+    yarn test || STATUS=$?
+
+    while read line; do
+      ./spec/support/test-c.sh "$line" || STATUS=$?
+    done < <(find spec -name '*_spec.c')
+
+    PLTCOLLECTS=":$(pwd)/lib" raco test spec/ || STATUS=$?
+
+    ./spec/support/haskell.rb || STATUS=$?
+    ;;
+  *)
+    echo "Unrecognized language: $1"
+    exit 1
+    ;;
+esac
+
+if [[ -z $STATUS ]]; then
+  echo "Test passed!"
+else
+  echo "Test failed with status: $STATUS"
+fi
+
 exit $STATUS


### PR DESCRIPTION
Make the following changes to `test.sh`:

* Take in a programming language argument, for example `./test.sh ruby` or `test.sh c`, which will run tests for just that language
* Pass all remaining arguments to the language-specific test scripts, so `./test.sh ruby spec/stack/stack_spec.rb:16` will resolve to `rspec spec/stack/stack_spec.rb:16`
* Update the c and Haskell test handling code to take a list of filenames and only run those test files so they work the same as the other languages
* Update the Haskell script to not remove all files before a test run, making the tests faster. It will still recompile everything if there has been a change